### PR TITLE
Fix stray backslash in `recheck.sh`

### DIFF
--- a/recheck.sh
+++ b/recheck.sh
@@ -56,7 +56,7 @@ stack install \
 mkdir -p examples/outputs
 for i in examples/*.tt; do
     n_src="${i%.tt}"
-    n="${n_src/examples/examples\/outputs}"
+    n="${n_src/examples/examples/outputs}"
 
     mkdir -p "${n}"
     find "${n}" -type f | xargs rm


### PR DESCRIPTION
This generated an additional `examples\` (with the backslash in the end) directory on macOS and possibly other platforms.